### PR TITLE
Scrolling Mode With Some Mouse Support

### DIFF
--- a/Typewriter.py
+++ b/Typewriter.py
@@ -8,10 +8,6 @@ import sublime_plugin
 
 offset = 0.0
 
-scrolling_mode_blocked_commands = [
-    "drag_select"
-]
-
 typing_mode_blocked_commands = [
     "drag_select",
     "undo",
@@ -76,8 +72,6 @@ class TypewriterMode(sublime_plugin.EventListener):
         settings = view.settings()
         if settings.get('typewriter_mode_typing') == 1:
             move_cursor_to_eof(view)
-        if settings.get('typewriter_mode_scrolling') == 1:
-            self.center_view(view)
 
     # Center View
     def center_view(self, view):
@@ -104,9 +98,6 @@ class TypewriterMode(sublime_plugin.EventListener):
     # Block Commands
     def on_text_command(self, view, cmd, args):
         blocked = False
-        if view.settings().get('typewriter_mode_scrolling') == 1:
-            blocked = self.block_commands(
-                view, cmd, args, scrolling_mode_blocked_commands)
         if view.settings().get('typewriter_mode_typing') == 1:
             blocked = self.block_commands(
                 view, cmd, args, typing_mode_blocked_commands)

--- a/Typewriter.py
+++ b/Typewriter.py
@@ -84,11 +84,14 @@ class TypewriterMode(sublime_plugin.EventListener):
         settings = view.settings()
         if settings.get('typewriter_mode_typing') == 1:
             move_cursor_to_eof(view)
-        if self.center_view_on_next_selection_modified:
+        if (settings.get('typewriter_mode_scrolling') and
+                self.center_view_on_next_selection_modified):
             self.center_view(view)
             self.center_view_on_next_selection_modified = False
 
     def on_post_text_command(self, view, command_name, args):
+        if not view.settings().get('typewriter_mode_scrolling'):
+            return
         if command_name in scrolling_mode_center_on_commands:
             self.center_view(view)
 
@@ -97,10 +100,14 @@ class TypewriterMode(sublime_plugin.EventListener):
         # is not being called. Ideally that is where we should call center_view so that
         # the view is centered on the new location. Instead, we 'remember' here that
         # we need to center the view on the next selection_modified event.
+        if not window.active_view().settings().get('typewriter_mode_scrolling'):
+            return
         if command_name in scrolling_mode_center_on_next_selection_modified_commands:
             self.center_view_on_next_selection_modified = True
 
     def on_modified(self, view):
+        if not view.settings().get('typewriter_mode_scrolling'):
+            return
         self.center_view(view)
 
     # Center View

--- a/Typewriter.py
+++ b/Typewriter.py
@@ -59,8 +59,9 @@ typing_mode_blocked_commands = [
     "delete_to_mark"
 ]
 
-# During Typing Mode cursor is always at EOF
+
 def move_cursor_to_eof(view):
+    # During Typing Mode cursor is always at EOF
     eof = view.size()
     sel = view.sel()[0]
     if sel.a != eof:
@@ -82,7 +83,7 @@ class TypewriterMode(sublime_plugin.EventListener):
     def center_view(self, view):
         sel = view.sel()
         region = sel[0] if len(sel) == 1 else None
-        if region != None:
+        if region is not None:
             global offset
             offset = sublime.load_settings('Typewriter.sublime-settings').get(
                 'typewriter_mode_scrolling_offset', 0.0) * view.line_height()
@@ -109,7 +110,7 @@ class TypewriterMode(sublime_plugin.EventListener):
         if view.settings().get('typewriter_mode_typing') == 1:
             blocked = self.block_commands(
                 view, cmd, args, typing_mode_blocked_commands)
-        if blocked == True:
+        if blocked:
             return ("do_nothing")
 
     def block_commands(self, view, cmd, args, blocked_cmds):

--- a/Typewriter.sublime-settings
+++ b/Typewriter.sublime-settings
@@ -4,7 +4,8 @@
 
     // Text commands after which to center the view when in scrolling mode.
     "scrolling_mode_center_on_commands": [
-        "move"
+        "move",
+        "move_to"
     ],
 
     // Center the view the next time the selection is modified after these

--- a/Typewriter.sublime-settings
+++ b/Typewriter.sublime-settings
@@ -1,9 +1,18 @@
 {
-	// Enables Typewriter Scrolling
-	"typewriter_mode_scrolling": false,
-
 	// Set a non-zero value to offset the center of the scrolling mode by that many lines.
 	"typewriter_mode_scrolling_offset": 0.0,
+
+    // Text commands after which to center the view when in scrolling mode.
+    "scrolling_mode_center_on_commands": [
+        "move"
+    ],
+
+    // Center the view the next time the selection is modified after these
+    // commands have run.
+    "scrolling_mode_center_on_next_selection_modified_commands": [
+        "find_next",
+        "find_prev"
+    ]
 
 	// Enables Typewriter Typing
 	// DO NOT USE as of v0.3.0.


### PR DESCRIPTION
I'm taking a different approach to implementing the scrolling mode. This way, you can still use the mouse to make selections and it won't affect the view until you start editing.

I'm still not sure if I like this a lot (it's a bit jarring when you start editing after moving the mouse), but I definitely like it better than not being able to move the mouse at all.
